### PR TITLE
Include user context in sx127x struct

### DIFF
--- a/include/sx127x.h
+++ b/include/sx127x.h
@@ -336,6 +336,8 @@ struct sx127x_t {
 
   bool use_implicit_header;
 
+  void* user_context;
+
   void (*rx_callback)(sx127x *, uint8_t *, uint16_t);
 
   void (*tx_callback)(sx127x *);
@@ -371,6 +373,21 @@ struct sx127x_t {
  *         - SX127X_OK                   on success
  */
 int sx127x_create(void *spi_device, sx127x *result);
+
+/**
+ * @brief Set user context
+ *
+ * @param user_context Callback context that can be retrieved in callbacks
+ * @param device Pointer to variable to hold the device handle
+ */
+void sx127x_set_user_context(void *user_context, sx127x *device);
+
+/**
+ * @brief Get user context
+ *
+ * @param device Pointer to variable to hold the device handle
+ */
+void* sx127x_get_user_context(sx127x *device);
 
 /**
  * @brief Set operating mode.

--- a/src/sx127x.c
+++ b/src/sx127x.c
@@ -561,6 +561,16 @@ int sx127x_create(void *spi_device, sx127x *result) {
   return SX127X_OK;
 }
 
+void sx127x_set_user_context(void *user_context, sx127x *device)
+{
+  device->user_context = user_context;
+}
+
+void* sx127x_get_user_context(sx127x *device)
+{
+  return device->user_context;
+}
+
 int sx127x_set_opmod(sx127x_mode_t opmod, sx127x_modulation_t modulation, sx127x *device) {
   // enforce DIO mappings for RX and TX
   if (modulation == SX127x_MODULATION_LORA) {


### PR DESCRIPTION
Hi @dernasherbrezon!

Here is another suggestion. It allows me to get rid of an ugly singleton in my cpp application. Now I can do something like:
```cpp
void sx127xRxCallback(sx127x* sx127x, uint8_t* data, uint16_t data_length)
{
    auto context = sx127x_get_user_context(sx127x);
    auto* loraDevice = static_cast<LoraDeviceSx127x*>(context);

    assert(loraDevice != nullptr);

    loraDevice->onRx(data, data_length);
}

LoraDeviceSx127x::LoraDeviceSx127x(/* ... */)
{
    auto status = sx127x_create(&mSpiFd, &mSx127x);
    if (status != 0) {
        throw std::runtime_error {"Could not create sx127x device"};
    }
    sx127x_set_user_context(this, &mSx127x);
    sx127x_rx_set_callback(sx127xRxCallback, &mSx127x);
}

void LoraDeviceSx127x::onRx(uint8_t* data, uint16_t data_length)
{
    /* Do stuff with received data */
}
```

This is just a proposal, let me know if it makes sense to you or do you see a different approach to achieve what I want to do? I can also add some tests when required.