### PR TITLE
fix: add missing require for ESP-IDF v6.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ set(srcs
 # When running from IDF build it as a component
 if (IDF_TARGET)
     list(APPEND srcs "${CMAKE_CURRENT_SOURCE_DIR}/src/sx127x_esp_spi.c")
-    idf_component_register(SRCS "${srcs}" INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include" REQUIRES "driver")
+    idf_component_register(SRCS "${srcs}" INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include" REQUIRES "driver esp_driver_spi")
 else()
     list(APPEND srcs "${CMAKE_CURRENT_SOURCE_DIR}/src/sx127x_linux_spi.c")
     add_library(sx127x STATIC ${srcs})

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,4 +1,4 @@
-version: "5.0.0"
+version: "5.0.1"
 description: "Library to work with Semtech chips sx127x"
 url: "https://github.com/dernasherbrezon/sx127x"
 license: "Apache-2.0"


### PR DESCRIPTION
This is a new requirement in the latest stable ESP-IDF that breaks compilation if not present